### PR TITLE
fix the doc uri error..

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ TestResults
 [Dd]ebug/
 [Rr]elease/
 x64/
+x86/
 *_i.c
 *_p.c
 *.ilk

--- a/DocSet.cs
+++ b/DocSet.cs
@@ -31,7 +31,7 @@ namespace Wox.Plugin.Doc
 
             foreach (string docPath in Directory.GetDirectories(docsetPath))
             {
-                string docName = Path.GetFileNameWithoutExtension(docPath);
+                string docName = Path.GetFileName(docPath);
                 string dbPath = Path.Combine(docPath, @"Contents\Resources\docSet.dsidx");
                 installedDocs.Add(new Doc
                     {

--- a/Wox.Plugin.Doc.csproj
+++ b/Wox.Plugin.Doc.csproj
@@ -37,10 +37,10 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.SQLite">
-      <HintPath>packages\System.Data.SQLite.Core.1.0.93.0\lib\net20\System.Data.SQLite.dll</HintPath>
+      <HintPath>..\..\packages\System.Data.SQLite.x64.1.0.93.0\lib\net20\System.Data.SQLite.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.SQLite.Linq">
-      <HintPath>packages\System.Data.SQLite.Linq.1.0.93.0\lib\net20\System.Data.SQLite.Linq.dll</HintPath>
+      <HintPath>..\..\packages\System.Data.SQLite.x64.1.0.93.0\lib\net20\System.Data.SQLite.Linq.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
@@ -50,7 +50,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
     <Reference Include="Wox.Plugin">
-      <HintPath>..\wox\Output\Debug\Wox.Plugin.dll</HintPath>
+      <HintPath>..\..\Output\Release\Wox.Plugin.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/packages.config
+++ b/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="System.Data.SQLite.Core" version="1.0.93.0" targetFramework="net35" />
   <package id="System.Data.SQLite.Linq" version="1.0.93.0" targetFramework="net35" />
-  <package id="System.Data.SQLite.x64" version="1.0.90.0" targetFramework="net35" />
+  <package id="System.Data.SQLite.x64" version="1.0.93.0" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
插件的doc uri有误，导致无法找到相应文档。原因是`docSet.cs`文件中使用`getFileNameWithoutExtension`获取的`docName`变量已经去掉了`.docset`子串。这里应该用`getFileName`或者在最后的`url`变量中加入`.docset`。
